### PR TITLE
Update Rerender Fix

### DIFF
--- a/src/components/NetworkPoll.tsx
+++ b/src/components/NetworkPoll.tsx
@@ -1,0 +1,9 @@
+import useNetworkStatus from '@/hooks/useNetworkStatus';
+
+// Separated component to not cause re-render to whole app
+const NetworkPolling = () => {
+  useNetworkStatus();
+  return <></>;
+};
+
+export default NetworkPolling;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,10 +7,10 @@ import StellarSdk from 'stellar-sdk';
 import TransactionNotification from '@/components/Notification';
 import { LoadingScreenController } from '@/context/LoadingScreen';
 
+import NetworkPolling from '@/components/NetworkPoll';
 import useMCStore from '@/stores/MCStore';
 import '@/styles/global.css';
-import { useCallback,useEffect,useMemo } from 'react';
-import NetworkPolling from '@/components/NetworkPoll';
+import { useCallback, useEffect } from 'react';
 
 declare global {
   interface Window {
@@ -33,7 +33,6 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
   useEffect(() => {
     fetchConfigCb();
   }, [fetchConfigCb]);
-
 
   return (
     <div className='relative overflow-x-hidden'>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,10 +7,10 @@ import StellarSdk from 'stellar-sdk';
 import TransactionNotification from '@/components/Notification';
 import { LoadingScreenController } from '@/context/LoadingScreen';
 
-import useNetworkStatus from '@/hooks/useNetworkStatus';
 import useMCStore from '@/stores/MCStore';
 import '@/styles/global.css';
 import { useCallback,useEffect,useMemo } from 'react';
+import NetworkPolling from '@/components/NetworkPoll';
 
 declare global {
   interface Window {
@@ -34,25 +34,14 @@ const MyApp = ({ Component, pageProps }: AppProps) => {
     fetchConfigCb();
   }, [fetchConfigCb]);
 
-  useNetworkStatus();
-
-  const MemoizedTransactionNotification = useMemo(
-    () => <TransactionNotification />,
-    []
-  );
-  const MemoizedComponent = useMemo(
-    () => (
-      <LoadingScreenController>
-        <Component {...pageProps} />
-      </LoadingScreenController>
-    ),
-    []
-  );
 
   return (
     <div className='relative overflow-x-hidden'>
-      {MemoizedTransactionNotification}
-      {MemoizedComponent}
+      <TransactionNotification />
+      <NetworkPolling />
+      <LoadingScreenController>
+        <Component {...pageProps} />
+      </LoadingScreenController>
     </div>
   );
 };


### PR DESCRIPTION
- encapsulate network status polling in a component

[rerender.webm](https://github.com/deep-ink-ventures/multiclique-frontend/assets/137761725/54cbebcf-4737-4473-ae2e-e9d15da86ec6)
